### PR TITLE
Auto variable capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ This allows more flexibility for designating responses you may want to cache to 
 {% endif %}
 ```
 
+## Automatic Variable Capturing
+
+You can enable automatic capturing of variables set with `{% set %}` in your twig files and have them passed as props to your Inertia components. This provides a cleaner, more intuitive way to pass data to your frontend without explicitly defining props.
+
+Enable this feature in your config:
+
+```php
+// config/inertia.php
+return [
+    // ...other settings
+    'autoCaptureVariables' => true,
+];
+```
+
 ## Pull in Variables
 
 Use the `pull` tag to include variables from a specified template and make them available in the current response twig file.
@@ -199,5 +213,11 @@ return [
      * '<catchall:.+>' => 'inertia/base/index',
      */
     'takeoverRouting' => true,
+
+    /**
+     * Whether to enable automatic capturing of variables set with `{% set %}` in your twig files
+     * and have them passed as props to your Inertia components.
+     */
+    'autoCaptureVariables' => false,
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -107,6 +107,51 @@ return [
 ];
 ```
 
+### Prune Filter
+
+With all variables being automatically captured and passed as props, you're inevitably going to have some large objects that you don't want to pass to your frontend. You can use the `prune` filter or function to remove properties from objects that are passed to your Inertia component.
+
+```twig
+{% set post = craft.entries.section('blog').one() %}
+
+{# Basic usage: simply pass an array of fields #}
+{% set post = blogPost|prune(["title", "author", "body", "url", "featuredImage"]) %}
+
+{# Advanced object syntax #}
+{% set post = blogPost|prune(
+  {
+    title: true,
+    id: true,
+    uri: true,
+    <!-- Related fields simple array syntax -->
+    author: ["username", "email"],
+    <!-- Related fields object syntax -->
+    mainImage: {
+      url: true,
+      uploader: {
+        <!-- Nested related fields -->
+        email: true,
+        username: true,
+      },
+    },
+    <!-- Matrix fields -->
+    contentBlocks: {
+      <!-- Denote query traits with $ prefix -->
+      <!-- https://www.yiiframework.com/doc/api/2.0/yii-db-querytrait -->
+      "$limit": 10,
+      <!-- Designate distinct prune fields per type with _ prefix -->
+      _body: {
+        body: true,
+        intro: true,
+      },
+      _fullWidthImage: {
+        image: ["url", "alt"],
+      },
+    },
+  }
+) %}
+```
+
 ## Pull in Variables
 
 Use the `pull` tag to include variables from a specified template and make them available in the current response twig file.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": "^8.2",
     "craftcms/cms": "^5.0.0",
-    "rareform/craft-prune": "@dev"
+    "rareform/craft-prune": "^0.1.0"
   },
   "require-dev": {
     "craftcms/generator": "^2.1"
@@ -31,11 +31,5 @@
       "yiisoft/yii2-composer": true,
       "craftcms/plugin-installer": true
     }
-  },
-  "repositories": [
-    {
-      "type": "path",
-      "url": "/Users/chasegiunta/git/craft-prune"
-    }
-  ]
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "require": {
     "php": "^8.2",
-    "craftcms/cms": "^5.0.0"
+    "craftcms/cms": "^5.0.0",
+    "rareform/craft-prune": "@dev"
   },
   "require-dev": {
     "craftcms/generator": "^2.1"
@@ -30,5 +31,11 @@
       "yiisoft/yii2-composer": true,
       "craftcms/plugin-installer": true
     }
-  }
+  },
+  "repositories": [
+    {
+      "type": "path",
+      "url": "/Users/chasegiunta/git/craft-prune"
+    }
+  ]
 }

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -73,7 +73,7 @@ class BaseController extends Controller
                 $stringResponse = '';
                 try {
                     // Check if variable capturing is enabled in settings
-                    $captureVariables = Inertia::getInstance()->settings->captureTemplateVariables ?? false;
+                    $captureVariables = Inertia::getInstance()->settings->autoCaptureVariables ?? false;
                     
                     // Add the inertia function regardless of the setting
                     Craft::$app->getView()->getTwig()->addFunction(new \Twig\TwigFunction('inertia', function($componentName, $props = []) use (&$component, &$explicitProps) {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -61,4 +61,10 @@ class Settings extends Model
      * @var string|null
      */
     public string|null $sharedPath = null;
+
+    /**
+     * Whether to capture template variables set via {% set %} and make them available as props
+     * @var bool
+     */
+    public bool $captureTemplateVariables = false;
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -66,5 +66,5 @@ class Settings extends Model
      * Whether to capture template variables set via {% set %} and make them available as props
      * @var bool
      */
-    public bool $captureTemplateVariables = false;
+    public bool $autoCaptureVariables = false;
 }


### PR DESCRIPTION
This pull request introduces several new features and improvements to the Inertia integration, including automatic variable capturing and a new prune filter for managing data passed to the frontend.

### Feature Additions:
* [`src/controllers/BaseController.php`](diffhunk://#diff-5a5152e32ffa8a585d302c0e3f9f1bb76c354a3234cee7194c2f035210086a68R67-R119): Implemented automatic capturing of variables set with `{% set %}` in Twig templates and passing them as props to Inertia components. Added error handling for JSON decoding and variable capturing. [[1]](diffhunk://#diff-5a5152e32ffa8a585d302c0e3f9f1bb76c354a3234cee7194c2f035210086a68R67-R119) [[2]](diffhunk://#diff-5a5152e32ffa8a585d302c0e3f9f1bb76c354a3234cee7194c2f035210086a68L89-R156)

### Configuration Changes:
* [`src/models/Settings.php`](diffhunk://#diff-f0aa84867d533a9e5f43ad96122eb529350107bddecc650e31ef80dbf573baadR64-R69): Added a new setting `autoCaptureVariables` to enable or disable automatic variable capturing.

### Dependency Updates:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L8-R9): Added a new dependency on `rareform/craft-prune` for the prune filter functionality.

### Twig Extension Enhancements:
* [`src/web/twig/InertiaExtension.php`](diffhunk://#diff-6e7ef0ff56215dff4b8935040f7a70cbf54b84768ed35a429c250515816ac77aR10): Added the prune filter and function to manage and prune data before passing it to Inertia components. [[1]](diffhunk://#diff-6e7ef0ff56215dff4b8935040f7a70cbf54b84768ed35a429c250515816ac77aR10) [[2]](diffhunk://#diff-6e7ef0ff56215dff4b8935040f7a70cbf54b84768ed35a429c250515816ac77aR23) [[3]](diffhunk://#diff-6e7ef0ff56215dff4b8935040f7a70cbf54b84768ed35a429c250515816ac77aR39) [[4]](diffhunk://#diff-6e7ef0ff56215dff4b8935040f7a70cbf54b84768ed35a429c250515816ac77aR48-R75)