### PR TITLE
Merge route parameters into template variables

### DIFF
--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -37,6 +37,11 @@ class BaseController extends Controller
         $element = $urlManager->getMatchedElement() ?: Craft::$app->getElements()->getElementByUri($uri);
 
         $templateVariables = [];
+
+        $requestParams = array_merge(
+            Craft::$app->getUrlManager()->getRouteParams() ?? []
+        );
+        $templateVariables = array_merge($requestParams, $templateVariables);
         $matchesTwigTemplate = false;
         $specifiedTemplate = null;
         $inertiaConfiguredDirectory = Inertia::getInstance()->settings->inertiaDirectory ?? null;


### PR DESCRIPTION
This pull request introduces a minor update to the `actionIndex` method in `BaseController.php`. The change ensures that route parameters from the request are merged into the template variables, which can improve the flexibility and accuracy of template rendering.

- Improved template variable handling:
  * Merges route parameters from the request (`getRouteParams()`) into the `$templateVariables` array, ensuring all relevant request data is available for template rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Templates now automatically receive URL route parameters, enabling more flexible page rendering based on the URL.
  * When both exist, URL route parameters can override existing template variables for more precise control.
* **Bug Fixes**
  * Resolved cases where URL parameters were not reflected in rendered pages, improving consistency between URLs and displayed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->