### PR TITLE
Update rareform/craft-prune version to ^0.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": "^8.2",
     "craftcms/cms": "^5.0.0",
-    "rareform/craft-prune": "^0.1.0"
+    "rareform/craft-prune": "^0.4.1"
   },
   "require-dev": {
     "craftcms/generator": "^2.1"


### PR DESCRIPTION
This pull request updates a dependency version in the `composer.json` file to ensure compatibility and access to new features.

Dependency update:

* Upgraded the `rareform/craft-prune` package from version `^0.1.0` to `^0.4.1` in `composer.json`.