### PR TITLE
feat: bypass Inertia rendering for file downloads

### DIFF
--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -115,9 +115,9 @@ class BaseController extends Controller
         }
 
         $mimeType = FileHelper::getMimeTypeByExtension($uri) ?: 'application/octet-stream';
-        $explicitBypass = (bool)(Craft::$app->params['__inertia_bypass'] ?? false);
+        $shouldDownload = (bool)(Craft::$app->params['__inertia_download'] ?? false);
 
-        if ($explicitBypass || $this->shouldForceAttachment($extension)) {
+        if ($shouldDownload || $this->shouldForceAttachment($extension)) {
             $response->setDownloadHeaders(pathinfo($uri, PATHINFO_BASENAME), $mimeType, false);
             return;
         }
@@ -127,7 +127,7 @@ class BaseController extends Controller
 
     private function shouldForceAttachment(string $extension): bool
     {
-        return !in_array($extension, ['html', 'htm', 'twig', 'php', 'xml', 'json', 'webmanifest', 'txt', 'js', 'mjs', 'css', 'map', 'svg'], true);
+        return in_array($extension, ['zip', 'tar', 'gz', 'tgz', 'bz2', 'xz', '7z', 'rar', 'pdf', 'exe', 'dmg', 'pkg', 'msi'], true);
     }
 
     /*

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -8,6 +8,7 @@ use craft\elements\Entry;
 use craft\elements\Category;
 
 use yii\web\View;
+use yii\helpers\FileHelper;
 
 use craft\web\Controller as Controller;
 
@@ -85,10 +86,7 @@ class BaseController extends Controller
             $result = Inertia::getInstance()->renderer->handleMatchedTemplate($specifiedTemplate ?? $inertiaTemplatePath, $uri, $templateVariables);
 
             if (is_string($result)) {
-                $extension = pathinfo($uri, PATHINFO_EXTENSION);
-                if ($extension) {
-                    Craft::$app->getResponse()->setDownloadHeaders(pathinfo($uri, PATHINFO_BASENAME), null, false);
-                }
+                $this->prepareStringResponse($uri);
                 return $result;
             }
 
@@ -101,6 +99,36 @@ class BaseController extends Controller
     }
 
     private ?string $only = '';
+
+    private function prepareStringResponse(string $uri): void
+    {
+        $extension = strtolower(pathinfo($uri, PATHINFO_EXTENSION));
+        if (!$extension) {
+            return;
+        }
+
+        $response = Craft::$app->getResponse();
+        $headers = $response->getHeaders();
+
+        if ($headers->has('Content-Disposition') || $headers->has('Content-Type')) {
+            return;
+        }
+
+        $mimeType = FileHelper::getMimeTypeByExtension($uri) ?: 'application/octet-stream';
+        $explicitBypass = (bool)(Craft::$app->params['__inertia_bypass'] ?? false);
+
+        if ($explicitBypass || $this->shouldForceAttachment($extension)) {
+            $response->setDownloadHeaders(pathinfo($uri, PATHINFO_BASENAME), $mimeType, false);
+            return;
+        }
+
+        $headers->setDefault('Content-Type', $mimeType);
+    }
+
+    private function shouldForceAttachment(string $extension): bool
+    {
+        return !in_array($extension, ['html', 'htm', 'twig', 'php', 'xml', 'json', 'webmanifest', 'txt', 'js', 'mjs', 'css', 'map', 'svg'], true);
+    }
 
     /*
      * Capture request for partial reload

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -82,7 +82,17 @@ class BaseController extends Controller
         }
 
         if ($matchesTwigTemplate) {
-            [$pageComponent, $props] = Inertia::getInstance()->renderer->handleMatchedTemplate($specifiedTemplate ?? $inertiaTemplatePath, $uri, $templateVariables);
+            $result = Inertia::getInstance()->renderer->handleMatchedTemplate($specifiedTemplate ?? $inertiaTemplatePath, $uri, $templateVariables);
+
+            if (is_string($result)) {
+                $extension = pathinfo($uri, PATHINFO_EXTENSION);
+                if ($extension) {
+                    Craft::$app->getResponse()->setDownloadHeaders(pathinfo($uri, PATHINFO_BASENAME), null, false);
+                }
+                return $result;
+            }
+
+            [$pageComponent, $props] = $result;
         } else {
             [$pageComponent, $props] = Inertia::getInstance()->errorHandler->renderError($request, 404);
         }

--- a/src/services/Renderer.php
+++ b/src/services/Renderer.php
@@ -36,28 +36,29 @@ class Renderer extends Component
                 return Inertia::getInstance()->errorHandler->handleError($exception);
             }
 
+            $bypassInertia = Craft::$app->params['__inertia_bypass'] ?? false;
+
             // New pattern: collect from Craft::$app->params
-            $pageComponent = Craft::$app->params['__inertia_page'] ?? null;
+            $pageComponent = $bypassInertia ? null : (Craft::$app->params['__inertia_page'] ?? null);
 
             $props = InertiaHelper::extractInertiaPropsFromString($stringResponse);
 
+            if ($bypassInertia) {
+                return $stringResponse;
+            }
+
             // Fallback: try to parse from output as before
             if ($pageComponent === null) {
+                $extension = strtolower(pathinfo($uri, PATHINFO_EXTENSION));
 
-                // If we've explicitly asked to bypass Inertia
-                if (Craft::$app->params['__inertia_bypass'] ?? false) {
+                // If it's a non-standard extension and we didn't find any props, bypass Inertia
+                if ($extension && !in_array($extension, ['html', 'twig', 'php'], true) && empty($props)) {
                     return $stringResponse;
                 }
 
                 // Decode JSON object from $stringResponse
                 $jsonData = json_decode($stringResponse, true);
                 if (json_last_error() !== JSON_ERROR_NONE) {
-
-                    // If it's a non-standard extension and we didn't find any props, bypass Inertia
-                    $extension = pathinfo($uri, PATHINFO_EXTENSION);
-                    if ($extension && !in_array(strtolower($extension), ['html', 'twig', 'php']) && empty($props)) {
-                        return $stringResponse;
-                    }
 
                     // If we can't decode JSON, log it and use default values
                     Craft::warning('JSON decoding failed: ' . json_last_error_msg() . '. Using default page component and props.', __METHOD__);

--- a/src/services/Renderer.php
+++ b/src/services/Renderer.php
@@ -43,9 +43,22 @@ class Renderer extends Component
 
             // Fallback: try to parse from output as before
             if ($pageComponent === null) {
+
+                // If we've explicitly asked to bypass Inertia
+                if (Craft::$app->params['__inertia_bypass'] ?? false) {
+                    return $stringResponse;
+                }
+
                 // Decode JSON object from $stringResponse
                 $jsonData = json_decode($stringResponse, true);
                 if (json_last_error() !== JSON_ERROR_NONE) {
+
+                    // If it's a non-standard extension and we didn't find any props, bypass Inertia
+                    $extension = pathinfo($uri, PATHINFO_EXTENSION);
+                    if ($extension && !in_array(strtolower($extension), ['html', 'twig', 'php']) && empty($props)) {
+                        return $stringResponse;
+                    }
+
                     // If we can't decode JSON, log it and use default values
                     Craft::warning('JSON decoding failed: ' . json_last_error_msg() . '. Using default page component and props.', __METHOD__);
                     // Set default page component based on route

--- a/src/web/twig/InertiaExtension.php
+++ b/src/web/twig/InertiaExtension.php
@@ -59,8 +59,13 @@ class InertiaExtension extends AbstractExtension
                 return '';
             }),
 
-            new TwigFunction('bypass', function () {
+            new TwigFunction('bypass', function (bool $download = false) {
                 Craft::$app->params['__inertia_bypass'] = true;
+
+                if ($download) {
+                    Craft::$app->params['__inertia_download'] = true;
+                }
+
                 return '';
             }),
 

--- a/src/web/twig/InertiaExtension.php
+++ b/src/web/twig/InertiaExtension.php
@@ -59,6 +59,11 @@ class InertiaExtension extends AbstractExtension
                 return '';
             }),
 
+            new TwigFunction('bypass', function () {
+                Craft::$app->params['__inertia_bypass'] = true;
+                return '';
+            }),
+
             new TwigFunction('prop', [$this, 'prop'], ['is_safe' => ['html']]),
 
             new TwigFunction('prune', [$this, 'pruneDataFilter']),


### PR DESCRIPTION
This PR allows bypassing Inertia rendering in two ways:

1. **Automatic Detection**: If the URI has an extension (e.g., .csv, .pdf) and no Inertia props or page components are defined in the template, it will render as a standard file download.
2. **Explicit Bypass**: Adds a `{{ bypass() }}` Twig function to explicitly opt-out of Inertia for a specific template.

This fixes issues where the plugin would intercept and wrap CSV downloads in an Inertia response shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File responses now set appropriate download/content headers automatically for identified file types and can be forced as attachments when needed.
  * Added a template function to explicitly bypass Inertia rendering for specific responses.
  * Non-standard file extensions are now detected and returned as raw rendered output instead of undergoing Inertia processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->