### PR TITLE
Add server-side rendering support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes for Inertia
 
+## Unreleased
+
+### Added
+- Added opt-in server-side rendering through an Inertia HTTP SSR server.
+- Added inertia_head() and inertia_app() Twig helpers with automatic client-rendering fallback.
+
 ## 2.0.0 - 2025-06-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ SSR is opt-in and follows Inertia's HTTP SSR protocol. The adapter sends the nor
 
 First, replace the hand-written app element in your root template with the Twig helpers:
 
-~~~twig
+```twig
 <!doctype html>
 <html>
   <head>
@@ -326,7 +326,7 @@ First, replace the hand-written app element in your root template with the Twig 
     {{ inertia_app() }}
   </body>
 </html>
-~~~
+```
 
 The inertia_app() helper also renders the existing client-side app element and escaped page payload whenever SSR is disabled or unavailable, so the same template supports both SSR and client rendering.
 

--- a/README.md
+++ b/README.md
@@ -252,9 +252,8 @@ return [
     /**
      * The root template that will be rendered when first loading your Inertia app
      * (https://inertiajs.com/the-protocol#html-responses).
-     * Includes the div the inertia app will be rendered to:
-     * `<div id="app" data-page="{{ page|json_encode }}"></div>`
-     * and calls the Inertia app `<script src="<path_to_app>/app.js"></script>`
+     * Includes the inertia_head() and inertia_app() Twig helpers,
+     * plus your application's client-side assets.
      */
     'view' => 'base.twig',
 
@@ -285,8 +284,65 @@ return [
      */
     'takeoverRouting' => null,
 
+    /**
+     * Enable server-side rendering for initial GET requests.
+     */
+    'ssrEnabled' => false,
+
+    /**
+     * Base URL of a trusted Inertia SSR server. The adapter posts page
+     * objects to the /render endpoint.
+     */
+    'ssrUrl' => 'http://127.0.0.1:13714',
+
+    /**
+     * Request timeout, in seconds, before falling back to client rendering.
+     */
+    'ssrTimeout' => 2.0,
+
+    /**
+     * Throw SSR errors instead of falling back. This is useful in automated
+     * tests, but is not recommended in production.
+     */
+    'ssrThrowOnError' => false,
+
 ];
 ```
+
+## Server-Side Rendering
+
+SSR is opt-in and follows Inertia's HTTP SSR protocol. The adapter sends the normal page object to a separately running Inertia SSR server and places the returned head and body markup into your root Twig template. Partial Inertia visits continue to return JSON and are never sent to the SSR server.
+
+First, replace the hand-written app element in your root template with the Twig helpers:
+
+~~~twig
+<!doctype html>
+<html>
+  <head>
+    {# Your normal head markup and client assets #}
+    {{ inertia_head() }}
+  </head>
+  <body>
+    {{ inertia_app() }}
+  </body>
+</html>
+~~~
+
+The inertia_app() helper also renders the existing client-side app element and escaped page payload whenever SSR is disabled or unavailable, so the same template supports both SSR and client rendering.
+
+Then:
+
+1. Configure your client entry point to hydrate server-rendered markup.
+2. Create and build an SSR entry point using the server package for your client framework.
+3. Run the built SSR server as a supervised background process.
+4. Set ssrEnabled to true and point ssrUrl at that server.
+
+See Inertia's [server-side rendering guide](https://inertiajs.com/docs/v3/advanced/server-side-rendering) for current Vue, React, and Svelte entry-point and hydration examples. Inertia v3's SSR server requires Node.js 22 or later and listens on port 13714 by default.
+
+If the SSR server cannot be reached, returns an error, or returns an invalid response, the adapter logs a warning and gracefully falls back to client rendering. Set ssrThrowOnError to true in automated tests if an SSR failure should fail the request instead.
+
+> [!IMPORTANT]
+> The SSR server receives the complete Inertia page object, including any authenticated-user or otherwise sensitive props. Keep the endpoint on loopback or a trusted private network; do not expose it publicly.
 
 ## Troubleshooting
 

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,21 @@
     "rareform/craft-prune": "^0.4.1"
   },
   "require-dev": {
-    "craftcms/generator": "^2.1"
+    "craftcms/generator": "^2.1",
+    "phpunit/phpunit": "^11.0"
   },
   "autoload": {
     "psr-4": {
       "rareform\\inertia\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "rareform\\inertia\\tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "test": "phpunit"
   },
   "extra": {
     "handle": "inertia",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="craft-inertia">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -27,6 +27,7 @@ class Plugin extends BasePlugin
                 "renderer" => \rareform\inertia\services\Renderer::class,
                 "errorHandler" => \rareform\inertia\services\ErrorHandler::class,
                 "pageResolver" => \rareform\inertia\services\PageResolver::class,
+                "ssrGateway" => \rareform\inertia\services\SsrGateway::class,
             ],
         ];
     }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -79,7 +79,7 @@ class Settings extends Model
         return [
             [['routingMode'], 'in', 'range' => ['opt-in', 'catchall'], 'skipOnEmpty' => true],
             [['ssrUrl'], 'string'],
-            [['ssrTimeout'], 'number', 'min' => 0.1],
+            [['ssrTimeout'], 'number', 'min' => 0.1, 'max' => 30],
         ];
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -6,13 +6,10 @@ use craft\base\Model;
 
 class Settings extends Model
 {
-    /** The template that will be rendered on first calls.
+    /** The template that will be rendered on initial requests.
      *
-     *  Includes the div the inertia app will be rendered to:
-     *  <div id="app" data-page="{{ page|json_encode }}"></div>
-     *
-     * and calls the inertia js app
-     * <script src="<path_to_app>/app.js"></script>
+     * Includes the inertia_head() and inertia_app() Twig helpers,
+     * plus the application's client-side assets.
      *
      */
     public string $view = 'base.twig';
@@ -26,6 +23,27 @@ class Settings extends Model
      *  Supports environment variables and aliases.
      */
     public array $assetsDirs = ['@webroot/assets'];
+
+    /**
+     * Whether initial GET requests should be rendered by an Inertia SSR server.
+     */
+    public bool $ssrEnabled = false;
+
+    /**
+     * Base URL for the Inertia SSR server.
+     * Supports environment variables.
+     */
+    public string $ssrUrl = 'http://127.0.0.1:13714';
+
+    /**
+     * Maximum number of seconds to wait for the SSR server.
+     */
+    public float $ssrTimeout = 2.0;
+
+    /**
+     * Throw SSR errors instead of gracefully falling back to client rendering.
+     */
+    public bool $ssrThrowOnError = false;
 
     /**
      * Whether Inertia routing is opt-in or catchall.
@@ -60,6 +78,8 @@ class Settings extends Model
     {
         return [
             [['routingMode'], 'in', 'range' => ['opt-in', 'catchall'], 'skipOnEmpty' => true],
+            [['ssrUrl'], 'string'],
+            [['ssrTimeout'], 'number', 'min' => 0.1],
         ];
     }
 }

--- a/src/models/SsrResponse.php
+++ b/src/models/SsrResponse.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace rareform\inertia\models;
+
+use yii\base\BaseObject;
+
+class SsrResponse extends BaseObject
+{
+    public string $head = '';
+    public string $body = '';
+}

--- a/src/services/Renderer.php
+++ b/src/services/Renderer.php
@@ -9,14 +9,19 @@ use craft\web\View;
 use craft\elements\Entry;
 use craft\elements\Category;
 use rareform\inertia\models\InertiaPage;
+use rareform\inertia\models\SsrResponse;
 use rareform\inertia\Plugin as Inertia;
 use rareform\inertia\helpers\InertiaHelper;
 use rareform\inertia\web\assets\axioshook\AxiosHookAsset;
 use yii\helpers\FileHelper;
+use yii\helpers\Html;
+use yii\helpers\Json;
 
 class Renderer extends Component
 {
     private array $captureStack = [];
+    private ?array $rootPagePayload = null;
+    private ?SsrResponse $ssrResponse = null;
 
     public function setPageComponent(string $component): void
     {
@@ -123,12 +128,41 @@ class Renderer extends Component
         $view = Craft::$app->getView();
         $view->registerAssetBundle(AxiosHookAsset::class, View::POS_END);
 
+        $this->rootPagePayload = $payload;
+        $this->ssrResponse = $request->getMethod() === 'GET'
+            ? Inertia::getInstance()->ssrGateway->dispatch($payload)
+            : null;
+
         $response->format = Response::FORMAT_RAW;
         $response->content = $view->renderPageTemplate($this->resolveRootView($page->rootView), [
             "page" => $payload,
         ]);
 
         return $response;
+    }
+
+    public function renderInertiaHead(): string
+    {
+        return $this->ssrResponse?->head ?? '';
+    }
+
+    public function renderInertiaApp(): string
+    {
+        if ($this->ssrResponse !== null) {
+            return $this->ssrResponse->body;
+        }
+
+        if ($this->rootPagePayload === null) {
+            return '';
+        }
+
+        return Html::tag('div', '', [
+            'id' => 'app',
+            'data-page' => Json::encode(
+                $this->rootPagePayload,
+                JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES,
+            ),
+        ]);
     }
 
     public function getInertiaProps(string $component, array $params = []): array

--- a/src/services/SsrGateway.php
+++ b/src/services/SsrGateway.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace rareform\inertia\services;
+
+use Craft;
+use craft\base\Component;
+use craft\helpers\App;
+use JsonException;
+use rareform\inertia\models\Settings;
+use rareform\inertia\models\SsrResponse;
+use rareform\inertia\Plugin as Inertia;
+use RuntimeException;
+use Throwable;
+
+class SsrGateway extends Component
+{
+    /**
+     * Dispatch an Inertia page object to the configured SSR server.
+     */
+    public function dispatch(array $page, ?Settings $settings = null): ?SsrResponse
+    {
+        $settings ??= Inertia::getInstance()->settings;
+
+        if (!$settings->ssrEnabled) {
+            return null;
+        }
+
+        $renderUrl = $this->getRenderUrl($settings);
+        if ($renderUrl === null) {
+            return $this->fail($page, 'The SSR URL is empty.', $settings);
+        }
+
+        try {
+            [$statusCode, $body] = $this->sendRequest(
+                $renderUrl,
+                $page,
+                $settings->ssrTimeout,
+            );
+        } catch (Throwable $exception) {
+            return $this->fail($page, $exception->getMessage(), $settings, $exception);
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            return $this->fail(
+                $page,
+                $this->getHttpErrorMessage($statusCode, $body),
+                $settings,
+            );
+        }
+
+        try {
+            $data = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            return $this->fail($page, 'The SSR server returned invalid JSON.', $settings, $exception);
+        }
+
+        if (!is_array($data) || !array_key_exists('body', $data) || !is_string($data['body'])) {
+            return $this->fail($page, 'The SSR response did not include a valid body.', $settings);
+        }
+
+        $head = $this->normalizeHead($data['head'] ?? []);
+        if ($head === null) {
+            return $this->fail($page, 'The SSR response did not include a valid head.', $settings);
+        }
+
+        return new SsrResponse([
+            'head' => $head,
+            'body' => $data['body'],
+        ]);
+    }
+
+    public function getRenderUrl(Settings $settings): ?string
+    {
+        $baseUrl = trim((string)App::parseEnv($settings->ssrUrl));
+
+        return $baseUrl === '' ? null : rtrim($baseUrl, '/') . '/render';
+    }
+
+    /**
+     * @return array{0: int, 1: string}
+     */
+    protected function sendRequest(string $url, array $page, float $timeout): array
+    {
+        $client = Craft::createGuzzleClient([
+            'connect_timeout' => $timeout,
+            'http_errors' => false,
+            'timeout' => $timeout,
+        ]);
+
+        $response = $client->post($url, [
+            'headers' => ['Accept' => 'application/json'],
+            'json' => $page,
+        ]);
+
+        return [$response->getStatusCode(), (string)$response->getBody()];
+    }
+
+    private function normalizeHead(mixed $head): ?string
+    {
+        if (is_string($head)) {
+            return $head;
+        }
+
+        if (!is_array($head)) {
+            return null;
+        }
+
+        foreach ($head as $element) {
+            if (!is_string($element)) {
+                return null;
+            }
+        }
+
+        return implode("\n", $head);
+    }
+
+    private function getHttpErrorMessage(int $statusCode, string $body): string
+    {
+        $message = "The SSR server returned HTTP {$statusCode}.";
+
+        try {
+            $data = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $message;
+        }
+
+        if (is_array($data) && isset($data['error']) && is_string($data['error'])) {
+            $message .= ' ' . $data['error'];
+        }
+
+        return $message;
+    }
+
+    private function fail(
+        array $page,
+        string $message,
+        Settings $settings,
+        ?Throwable $previous = null,
+    ): ?SsrResponse {
+        $component = is_string($page['component'] ?? null) ? $page['component'] : 'unknown';
+        $fullMessage = "Inertia SSR failed for component [{$component}]: {$message}";
+
+        Craft::warning($fullMessage, __METHOD__);
+
+        if ($settings->ssrThrowOnError) {
+            throw new RuntimeException($fullMessage, 0, $previous);
+        }
+
+        return null;
+    }
+}

--- a/src/web/twig/InertiaExtension.php
+++ b/src/web/twig/InertiaExtension.php
@@ -76,6 +76,22 @@ class InertiaExtension extends AbstractExtension
 
             new TwigFunction('prop', [$this, 'prop'], ['is_safe' => ['html']]),
 
+            new TwigFunction('inertia_head', function () {
+                if (Craft::$app->has('plugins') && ($plugin = Craft::$app->plugins->getPlugin('inertia')) !== null) {
+                    return $plugin->renderer->renderInertiaHead();
+                }
+
+                return '';
+            }, ['is_safe' => ['html']]),
+
+            new TwigFunction('inertia_app', function () {
+                if (Craft::$app->has('plugins') && ($plugin = Craft::$app->plugins->getPlugin('inertia')) !== null) {
+                    return $plugin->renderer->renderInertiaApp();
+                }
+
+                return '';
+            }, ['is_safe' => ['html']]),
+
             new TwigFunction('prune', [$this, 'pruneDataFilter']),
         ];
     }

--- a/tests/RendererTest.php
+++ b/tests/RendererTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace rareform\inertia\tests;
+
+use Craft;
+use craft\web\Request;
+use craft\web\Response;
+use craft\web\View;
+use PHPUnit\Framework\TestCase;
+use rareform\inertia\models\InertiaPage;
+use rareform\inertia\models\Settings;
+use rareform\inertia\models\SsrResponse;
+use rareform\inertia\Plugin as Inertia;
+use rareform\inertia\services\Renderer;
+use rareform\inertia\services\SsrGateway;
+
+class RendererTest extends TestCase
+{
+    private mixed $originalApp;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalApp = Craft::$app;
+    }
+
+    protected function tearDown(): void
+    {
+        Craft::$app = $this->originalApp;
+
+        parent::tearDown();
+    }
+
+    public function testItOnlyDispatchesSsrForGetRequests(): void
+    {
+        $method = 'GET';
+        $request = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getMethod', 'getUrl'])
+            ->getMock();
+        $request->method('getMethod')->willReturnCallback(function () use (&$method) {
+            return $method;
+        });
+        $request->method('getUrl')->willReturn('/posts');
+
+        $response = new Response();
+        $view = $this->getMockBuilder(View::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['registerAssetBundle', 'renderPageTemplate'])
+            ->getMock();
+        $view->method('renderPageTemplate')->willReturn('<html></html>');
+
+        Craft::$app = new RendererTestApplication($request, $response, $view);
+
+        $payload = [
+            'component' => 'Posts/Index',
+            'props' => ['posts' => []],
+            'url' => '/posts',
+            'version' => 'test',
+        ];
+        $ssrResponse = new SsrResponse([
+            'head' => '<title>SSR</title>',
+            'body' => '<div id="app">SSR</div>',
+        ]);
+
+        $gateway = $this->getMockBuilder(SsrGateway::class)
+            ->onlyMethods(['dispatch'])
+            ->getMock();
+        $gateway->expects(self::once())
+            ->method('dispatch')
+            ->with($payload)
+            ->willReturn($ssrResponse);
+
+        $plugin = $this->getMockBuilder(Inertia::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getInertiaVersion', 'getSettings', 'get', 'has'])
+            ->getMock();
+        $plugin->method('getInertiaVersion')->willReturn('test');
+        $plugin->method('getSettings')->willReturn(new Settings());
+        $plugin->method('has')
+            ->willReturnCallback(fn(string $id, bool $checkInstance = false) => $id === 'ssrGateway');
+        $plugin->method('get')
+            ->with('ssrGateway')
+            ->willReturn($gateway);
+        Craft::$app->loadedModules[Inertia::class] = $plugin;
+
+        $renderer = new RendererWithoutSharedProps();
+        $renderer->renderPage($this->page());
+
+        self::assertSame('<title>SSR</title>', $renderer->renderInertiaHead());
+        self::assertSame('<div id="app">SSR</div>', $renderer->renderInertiaApp());
+
+        $method = 'POST';
+        $renderer->renderPage($this->page());
+
+        self::assertSame('', $renderer->renderInertiaHead());
+    }
+
+    private function page(): InertiaPage
+    {
+        return new InertiaPage([
+            'component' => 'Posts/Index',
+            'props' => ['posts' => []],
+        ]);
+    }
+}
+
+class RendererWithoutSharedProps extends Renderer
+{
+    public function getInertiaProps(string $component, array $params = []): array
+    {
+        return $params;
+    }
+}
+
+class RendererTestApplication
+{
+    public array $loadedModules = [];
+
+    public function __construct(
+        public Request $request,
+        private readonly Response $response,
+        private readonly View $view,
+    ) {
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+
+    public function getView(): View
+    {
+        return $this->view;
+    }
+}

--- a/tests/SsrGatewayTest.php
+++ b/tests/SsrGatewayTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace rareform\inertia\tests;
+
+use PHPUnit\Framework\TestCase;
+use rareform\inertia\models\Settings;
+use rareform\inertia\services\SsrGateway;
+use RuntimeException;
+use Throwable;
+
+class SsrGatewayTest extends TestCase
+{
+    public function testItDoesNotDispatchWhenSsrIsDisabled(): void
+    {
+        $gateway = new FakeSsrGateway();
+
+        self::assertNull($gateway->dispatch($this->page(), $this->settings([
+            'ssrEnabled' => false,
+        ])));
+        self::assertSame(0, $gateway->requestCount);
+    }
+
+    public function testItDispatchesAndNormalizesTheResponse(): void
+    {
+        $gateway = new FakeSsrGateway();
+        $gateway->response = [200, json_encode([
+            'head' => ['<title>Test</title>', '<meta name="description" content="SSR">'],
+            'body' => '<div id="app">Rendered</div>',
+        ], JSON_THROW_ON_ERROR)];
+
+        $response = $gateway->dispatch($this->page(), $this->settings());
+
+        self::assertNotNull($response);
+        self::assertSame("<title>Test</title>\n<meta name=\"description\" content=\"SSR\">", $response->head);
+        self::assertSame('<div id="app">Rendered</div>', $response->body);
+        self::assertSame('http://127.0.0.1:13714/render', $gateway->lastUrl);
+        self::assertSame(2.0, $gateway->lastTimeout);
+    }
+
+    public function testItGracefullyFallsBackWhenRenderingFails(): void
+    {
+        $gateway = new FakeSsrGateway();
+        $gateway->response = [500, json_encode(['error' => 'window is not defined'], JSON_THROW_ON_ERROR)];
+
+        self::assertNull($gateway->dispatch($this->page(), $this->settings()));
+    }
+
+    public function testItCanThrowWhenRenderingFails(): void
+    {
+        $gateway = new FakeSsrGateway();
+        $gateway->exception = new RuntimeException('Connection refused');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Inertia SSR failed for component [Posts/Index]: Connection refused',
+        );
+
+        $gateway->dispatch($this->page(), $this->settings([
+            'ssrThrowOnError' => true,
+        ]));
+    }
+
+    public function testItRejectsMalformedResponses(): void
+    {
+        $gateway = new FakeSsrGateway();
+        $gateway->response = [200, '{"head":[],"body":false}'];
+
+        self::assertNull($gateway->dispatch($this->page(), $this->settings()));
+    }
+
+    private function page(): array
+    {
+        return [
+            'component' => 'Posts/Index',
+            'props' => ['posts' => []],
+            'url' => '/posts',
+            'version' => 'test',
+        ];
+    }
+
+    private function settings(array $config = []): Settings
+    {
+        return new Settings(array_merge([
+            'ssrEnabled' => true,
+            'ssrUrl' => 'http://127.0.0.1:13714/',
+            'ssrTimeout' => 2.0,
+        ], $config));
+    }
+}
+
+class FakeSsrGateway extends SsrGateway
+{
+    public int $requestCount = 0;
+    public array $response = [200, '{"head":[],"body":""}'];
+    public ?Throwable $exception = null;
+    public ?string $lastUrl = null;
+    public ?float $lastTimeout = null;
+
+    protected function sendRequest(string $url, array $page, float $timeout): array
+    {
+        $this->requestCount++;
+        $this->lastUrl = $url;
+        $this->lastTimeout = $timeout;
+
+        if ($this->exception !== null) {
+            throw $this->exception;
+        }
+
+        return $this->response;
+    }
+}


### PR DESCRIPTION
## What changed

- adds an opt-in HTTP SSR gateway compatible with Inertia's `/render` protocol
- dispatches only initial GET page loads; partial Inertia visits remain JSON responses
- adds `inertia_head()` and `inertia_app()` Twig helpers with automatic CSR fallback
- adds SSR URL, timeout, and throw-on-error settings
- documents hydration, SSR server setup, fallback behavior, and endpoint security
- adds focused gateway tests and PHPUnit configuration

## Why

Craft currently builds the complete Inertia page object but always leaves the initial render to the browser. This adds the missing server-rendering bridge while keeping frontend bundling and the Node process under the consuming project's control.

SSR failures log a warning and fall back to the existing client-rendered shell by default. `ssrThrowOnError` can make failures explicit in automated tests.

Closes #4.

## Validation

- parsed all 14 PHP source/test files successfully with `php-parser`
- validated `composer.json`
- validated `phpunit.xml.dist`
- `git diff --check`
- PHPUnit was not executed because PHP is unavailable in the runner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in server-side rendering for Inertia pages.
  * Added `inertia_head()` and `inertia_app()` Twig helpers for rendering SSR output.
  * Added configurable SSR endpoint, timeout, and error-handling options.
  * Added automatic client-side rendering fallback when SSR is unavailable.

* **Documentation**
  * Added setup, configuration, hydration, fallback, and security guidance for SSR.

* **Tests**
  * Added coverage for successful rendering, fallback behavior, configuration, and malformed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->